### PR TITLE
Better handling of subprocess args and stderr redirection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,9 +112,7 @@ export async function executeJar(jarPath: string, args?: string[]): Promise<Chil
   const javaCommand = await getJavaCommand();
   var output = spawn(javaCommand, getJarArgs(jarPath, args));
   if (!!output.stderr) {
-    output.stderr.on("data", (stderr: any) => {
-      console.error(`${stderr}`);
-    });
+    output.stderr.pipe(process.stderr);
   }
   return output;
 }
@@ -132,9 +130,7 @@ export async function executeClassWithCP(className: string, classPaths?: string[
   const javaCommand = await getJavaCommand();
   var output = spawn(javaCommand, getClassArgs(className, classPaths, args));
   if (!!output.stderr) {
-    output.stderr.on("data", (stderr: any) => {
-      console.error(`${stderr}`);
-    });
+    output.stderr.pipe(process.stderr);
   }
   return output;
 }


### PR DESCRIPTION
* Pipe output instead of `console.error`
  * `console.error` adds extra newlines and possibly does other formatting which we don't want
* By using `child_process.spawn` instead of  `child_process.exec`, we don't have to do so much manual handling of args.
  * This was causing me problems trying to execute PMD as flags were getting sent wrapped in quotes.