### PR TITLE
Add option to disallow using system java

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -3,8 +3,8 @@
 ## install([version], [options])
 Installs a JRE copy for the app, if no Java is installed on the system.
 
-**Kind**: global function  
-**Returns**: Promise<string> - Resolves to the installation directory or rejects an error  
+**Kind**: global function
+**Returns**: Promise<string> - Resolves to the installation directory or rejects an error
 
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
@@ -16,8 +16,9 @@ Installs a JRE copy for the app, if no Java is installed on the system.
 | [options.release] | <code>string</code> | <code>&quot;latest&quot;</code> | Release |
 | [options.type] | <code>string</code> | <code>&quot;jre&quot;</code> | Binary Type (`jre`/`jdk`) |
 | [options.heap_size] | <code>string</code> |  | Heap Size (`normal`/`large`) |
+| [options.allow_system_java] | <code>boolean</code> |  | Allow using system-wide java installation rather than downloading and installing a local copy (defaults to `true`) |
 
-**Example**  
+**Example**
 ```js
 const njc = require('node-java-connector')
 


### PR DESCRIPTION
New option when calling `install()`: allow_system_java. Defaults to `true` for backwards-compatibility. If set to `false`, presence of system-wide java installation is not checked when installing. Useful for when the system-wide java installation cannot be known/controlled and may be incompatible.

`getJavaCommand` was refactored to use a locally-installed java before system-wide installation (previously was functioning the other way around). This should have no impact to existing installations that are using the system-wide installation as they will have no local installation.