### PR TITLE
Update find-java-home dependancy to resolve symlink error

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "Nico Lueg",
   "license": "MIT",
   "dependencies": {
-    "find-java-home": "^1.2.0",
+    "find-java-home": "^1.2.1",
     "node-fetch": "^2.6.0",
     "tar": "^6.1.0",
     "typescript": "^4.2.4",


### PR DESCRIPTION
(apologies for the separate PRs - just realised this was a thing)

The newer version of `find-java-home` fixed a bug in symlink resolution. I've been encountering this bug frequently on OSX. I'd have thought npm would just install the newer version automagically, but apparently it doesn't.