### PR TITLE
feat: support Apple silicon processors using Rosetta 2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,8 @@ export async function install(version: number = 8, options: any = {}) {
   if (!options.arch) {
     if (/^ppc64|s390x|x32|x64$/g.test(process.arch)) options.arch = process.arch
     else if (process.arch === 'ia32') options.arch = 'x32'
+    // support Apple silicon processors using Rosetta 2 as there is no arm64 (aarch64) openjdk release yet
+    else if (options.os === 'mac') options.arch = 'x64'
     else return Promise.reject(new Error('Unsupported architecture'))
   }
 


### PR DESCRIPTION
Currently the installation fails on a Mac with M1 (silicon) processor:

> Unsupported architecture

There is no official openjdk release for darwin/amd64 (`mac/aarch64`) yet.
We can probably expect one with version 17: https://openjdk.java.net/jeps/391.

This makes the installation pass and it should work if [Rosetta 2](https://support.apple.com/en-us/HT211861) is set up.