### PR TITLE
Installation path as an option

### DIFF
--- a/src/execute/execute-class-with-cp.ts
+++ b/src/execute/execute-class-with-cp.ts
@@ -9,14 +9,17 @@ import { getJavaCommand } from '../helper/java-command';
  * @param {string} className Java classname to execute.
  * @param {string[]} [classPaths] optional Zip/Jar files to include to classpath.
  * @param {string[]} [args] optional arguments that will be appended while executing
+ * @param {string} [jrePath] optional path to a JRE installation if other than default.
  * @returns {Promise<ChildProcess>}
  */
 export async function executeClassWithCP(
   className: string,
   classPaths?: string[],
-  args?: string[]
+  args?: string[],
+  jrePath?: string
 ): Promise<ChildProcess> {
-  const javaCommand = await getJavaCommand();
+  const jreInstallPath = resolveJREInstallPath(jrePath);
+  const javaCommand = await getJavaCommand(jreInstallPath);
   const output = spawn(javaCommand, getClassArgs(className, classPaths, args));
   if (output.stderr) {
     output.stderr.pipe(process.stderr);
@@ -39,4 +42,11 @@ function getClassArgs(
 function joinPaths(paths: string[] = []): string {
   const pathSep = process.platform === 'win32' ? ';' : ':';
   return `${paths.join(pathSep)}`;
+}
+
+function resolveJREInstallPath(jrePath?: string) {
+  if(jrePath != null) {
+    return jrePath;
+  }
+  return __dirname;
 }

--- a/src/execute/execute-jar.ts
+++ b/src/execute/execute-jar.ts
@@ -8,13 +8,16 @@ import { getJavaCommand } from '../helper/java-command';
  * @export
  * @param {string} jarPath path to the jar-file which should be executed
  * @param {string[]} [args] optional arguments that will be appended while executing
+ * @param {string} [jrePath] optional path to a JRE installation if other than default.
  * @returns {Promise<ChildProcess>}
  */
 export async function executeJar(
   jarPath: string,
-  args?: string[]
+  args?: string[],
+  jrePath?: string
 ): Promise<ChildProcess> {
-  const javaCommand = await getJavaCommand();
+  const jreInstallPath = resolveJREInstallPath(jrePath);
+  const javaCommand = await getJavaCommand(jreInstallPath);
   const output = spawn(javaCommand, getJarArgs(jarPath, args));
   if (output.stderr) {
     output.stderr.pipe(process.stderr);
@@ -27,4 +30,11 @@ function getJarArgs(jarPath: string, args: string[] = []): string[] {
   ret.unshift(jarPath);
   ret.unshift('-jar');
   return ret;
+}
+
+function resolveJREInstallPath(jrePath?: string) {
+  if(jrePath != null) {
+    return jrePath;
+  }
+  return __dirname;
 }

--- a/src/helper/java-command.ts
+++ b/src/helper/java-command.ts
@@ -5,9 +5,9 @@ import { jrePath } from '../constants';
 import { getExecutable } from './get-executable';
 import { systemJavaExists } from './java-exists';
 
-export async function getJavaCommand(): Promise<string> {
+export async function getJavaCommand(jreInstallPath: string): Promise<string> {
   try {
-    return getJavaString();
+    return getJavaString(jreInstallPath);
   } catch (e) {
     // ignore exception
   }
@@ -19,8 +19,8 @@ export async function getJavaCommand(): Promise<string> {
   throw Error('Unable to find locally-installed java or system-wide java');
 }
 
-function getJavaString(): string {
-  const pathOfJreFolder = path.join(path.resolve(__dirname), '../', jrePath);
+function getJavaString(jreInstallPath: string): string {
+  const pathOfJreFolder = path.join(path.resolve(jreInstallPath), '../', jrePath);
 
   const files = readdirSync(pathOfJreFolder);
   const file = files.filter((name) => !name.startsWith('._'));

--- a/src/install/extract.ts
+++ b/src/install/extract.ts
@@ -8,8 +8,8 @@ import { Entry } from 'yauzl';
 import { jrePath } from '../constants';
 import { createDir } from '../helper/create-dir';
 
-export function extract(filePath: string): Promise<string> {
-  const dir = path.join(path.dirname(__dirname), jrePath);
+export function extract(filePath: string, installPath: string): Promise<string> {
+  const dir = path.join(path.dirname(installPath), jrePath);
 
   return createDir(dir).then(() => {
     return path.extname(filePath) === '.zip'

--- a/src/install/generate-install-options.spec.ts
+++ b/src/install/generate-install-options.spec.ts
@@ -1,0 +1,17 @@
+import { generateInstallOptions } from './generate-install-options';
+
+describe('generate-options', () => {
+  it('generates default options if none is provided', () => {
+    const defaultOptions = generateInstallOptions();
+    expect(defaultOptions.feature_version).toBeDefined();
+    expect(defaultOptions.os).toBeDefined();
+    expect(defaultOptions.arch).toBeDefined();
+    expect(defaultOptions.image_type).toBeDefined();
+    expect(defaultOptions.openjdk_impl).toBeDefined();
+    expect(defaultOptions.release_type).toBeDefined();
+    expect(defaultOptions.heap_size).toBeDefined();
+    expect(defaultOptions.vendor).toBeDefined();
+    expect(defaultOptions.allow_system_java).toBeDefined();
+    expect(defaultOptions.install_path).toBeDefined();
+  });
+});

--- a/src/install/install.spec.ts
+++ b/src/install/install.spec.ts
@@ -1,8 +1,9 @@
 import { getUrlToCall } from './install';
+import { generateInstallOptions } from './generate-install-options';
 
 describe('install-jdk', () => {
-  it('default url for no parameters', () => {
-    const url = getUrlToCall({ os: 'windows' });
+  it('creates valid url for default parameters', () => {
+    const url = getUrlToCall(generateInstallOptions());
     expect(url).toBe(
       'https://api.adoptopenjdk.net/v3/binary/latest/8/ga/windows/x64/jre/hotspot/normal/adoptopenjdk'
     );

--- a/src/install/install.typings.ts
+++ b/src/install/install.typings.ts
@@ -46,6 +46,11 @@ export type InstallOptions = {
    * (defaults to false)
    */
   allow_system_java?: boolean;
+
+  /**
+   * The path where to install the JRE. (defaults to __dirname)
+   */
+   install_path?: string;
 };
 
 export const defaultOptions: InstallOptions = {
@@ -56,6 +61,7 @@ export const defaultOptions: InstallOptions = {
   heap_size: 'normal',
   vendor: 'adoptopenjdk',
   allow_system_java: false,
+  install_path: __dirname,
 };
 
 export type SupportedOs =


### PR DESCRIPTION
I added install_path as an option to the install function to let the user be able to specify where njc should download and install the jre. I also had to add the installation path to both executeJar and execute-jar and execute-class-with-cp to be able to use the JRE installed in another location than default. 
Default path is till __dirname.
My use case is that I want to be able to use NJC inside of a electron app. But the user is not allowed to access files inside of the electron package (__dirname).
In my solution installPath is passed around alot and needed for both install and execution. I could not come up with a more tidy solution but please have a look if you can figure out a way to reuse the install_path for both install and execution. 