### PR TITLE
Java dir fixes

### DIFF
--- a/src/helper/java-command.ts
+++ b/src/helper/java-command.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 import { jrePath } from '../constants';
 import { getExecutable } from './get-executable';
-import { systemJavaExists } from './java-exists';
+import { getSystemJavaHome } from './java-exists';
 
 export async function getJavaCommand(jreInstallPath: string): Promise<string> {
   try {
@@ -12,8 +12,9 @@ export async function getJavaCommand(jreInstallPath: string): Promise<string> {
     // ignore exception
   }
 
-  if (await systemJavaExists()) {
-    return 'java';
+  const javaHome = await getSystemJavaHome();
+  if (javaHome) {
+    return path.join(javaHome, getExecutable());
   }
 
   throw Error('Unable to find locally-installed java or system-wide java');

--- a/src/helper/java-command.ts
+++ b/src/helper/java-command.ts
@@ -1,4 +1,4 @@
-import { readdirSync } from 'fs';
+import * as fs from 'fs';
 import * as path from 'path';
 
 import { jrePath } from '../constants';
@@ -21,13 +21,30 @@ export async function getJavaCommand(jreInstallPath: string): Promise<string> {
 }
 
 function getJavaString(jreInstallPath: string): string {
-  const pathOfJreFolder = path.join(path.resolve(jreInstallPath), '../', jrePath);
+  const pathOfJreFolder = path.join(
+    path.resolve(jreInstallPath),
+    '../',
+    jrePath
+  );
 
-  const files = readdirSync(pathOfJreFolder);
-  const file = files.filter((name) => !name.startsWith('._'));
-  if (file.length > 1) {
+  const files = fs.readdirSync(pathOfJreFolder);
+  const file = files
+    .filter((name) => !name.startsWith('._'))
+    .map((name) => path.join(pathOfJreFolder, name, getExecutable()))
+    .filter(hasJavaExe);
+
+  if (file.length == 0) {
     throw Error('JRE installation failed! Please install the package again.');
   }
 
-  return path.join(pathOfJreFolder, file[0], getExecutable());
+  return file[0];
+}
+
+function hasJavaExe(javaExe: string): boolean {
+  try {
+    fs.accessSync(javaExe, fs.constants.X_OK);
+    return true;
+  } catch (e) {
+    return false;
+  }
 }

--- a/src/helper/java-exists.ts
+++ b/src/helper/java-exists.ts
@@ -12,7 +12,7 @@ export async function systemJavaExists(): Promise<boolean> {
   return ret;
 }
 
-async function getSystemJavaHome(): Promise<string> {
+export async function getSystemJavaHome(): Promise<string> {
   let ret = '';
 
   await findJavaHome({ allowJre: true }, async (err, home) => {


### PR DESCRIPTION
I discovered that on my install (via pmd-bin):

- node-java-connector installs failed as there were 2 JREs in the folder
- the system JDK wasn't used as it was not on the `PATH` (only `JAVA_HOME`) 

This PR fixes both those issues